### PR TITLE
Refactor `assemble` into 3 steps

### DIFF
--- a/expressions.nim
+++ b/expressions.nim
@@ -1,7 +1,7 @@
 import std/setutils, strutils, math
 import types, parse
 
-const CURRENT_ADDRESS = int.high
+const CURRENT_ADDRESS* = int.high
 
 func `$`*(exp: expression): string =
   case exp.exp_kind:

--- a/main.nim
+++ b/main.nim
@@ -1,0 +1,72 @@
+import std/parseopt
+import std/strformat
+import std/os
+import isa_spec
+
+type arguments = object
+    exit_code: int
+    message: string
+
+    spec_file: string
+    asm_files: seq[string]
+
+proc get_help(): string =
+    result = fmt"""
+isa-spec configurable assembler
+    {getAppFilename()} SPEC-FILE [ASM-FILES ...]
+Options:
+    -h, --help          print this message
+"""
+
+
+proc parseArguments(): arguments =
+    var p = initOptParser("")
+
+    while true:
+        p.next()
+        case p.kind
+        of cmdEnd: break
+        of cmdShortOption, cmdLongOption:
+            if p.key in ["h", "help"]:
+                result.message = get_help()
+                result.exit_code = 0
+                return
+            else:
+                result.message = fmt"Unknown option {p.key}"
+                result.exit_code = 2
+                return
+        of cmdArgument:
+            if result.spec_file == "":
+                result.spec_file = p.key
+            else:
+                result.asm_files.add p.key
+    if result.spec_file == "":
+        result.message = fmt"Expected the spec file as the first argument."
+        result.exit_code = 2
+        return
+    if result.asm_files.len == 0:
+        result.message = fmt"Expected at least one assembly file after the spec file."
+        result.exit_code = 2
+        return
+
+
+when isMainModule:
+    let args = parseArguments()
+    if args.message != "":
+        quit(args.message, args.exit_code)
+
+    let spec_source = readFile($args.spec_file)
+    let spec_result = parse_isa_spec(spec_source)
+    if spec_result.error != "":
+      quit "'" & $args.spec_file & "' error: " & spec_result.error & " at line " & $spec_result.error_line & ".", 1
+    for asm_file in args.asm_files:
+        let asm_source = readFile($asm_file)
+        let asm_result = assemble("", asm_file, spec_result.spec, asm_source)
+        if asm_result.error != "":
+            quit "'" & $asm_file & "' error: " & asm_result.error & " at line " & $asm_result.error_line & ".", 1
+        let output_file = asm_file.changeFileExt("bin")
+        if asm_result.machine_code.len != 0:
+          writeFile($output_file, asm_result.machine_code)
+        else:
+          writeFile($output_file, "") # An empty buffer causes an exception
+        echo fmt"Wrote result of assembling {asm_file} to {output_file}."

--- a/run_tests.nim
+++ b/run_tests.nim
@@ -1,7 +1,7 @@
 import tables
 import isa_spec
 
-const STOP_AT_FIRST_FAIL = true
+const STOP_AT_FIRST_FAIL = false
 
 type test = object
   spec_error: string

--- a/types.nim
+++ b/types.nim
@@ -85,6 +85,14 @@ type define_value* = object
   public*: bool
   value*: uint64
 
+type file_location* = object
+  file*: string
+  line*: int # We might want to expand this to start/end column
+
+type error* = object
+  loc*: file_location
+  message*: string
+
 type assembly_result* = object
   machine_code*: seq[uint8]
   line_to_byte*: seq[int]


### PR DESCRIPTION
This is based on #1 , so that one should be merged first.

This keeps the external interface completely intact, but changes the internal steps a bit.

The core idea is to split `assemble` into three phases:

- `pre_assemble`: parse the assembly into a list of segments, turning stuff that is already fully defined into a simple list of bytes and the rest of instructions into `relxables`, with potentially multiple possible definitions
- `relax`: adjust the selected definitions of the `relaxable` instructions identified in the previous step. Not yet implemented
- `finalize`: Turn the list of segments produced by the previous phase into a single list of bytes. Also copies around stuff to match the expected interface for the game.