### PR TITLE
Make roundtrippping work

### DIFF
--- a/isa_spec.nim
+++ b/isa_spec.nim
@@ -8,7 +8,15 @@ func instruction_to_string*(isa_spec: isa_spec, instruction: instruction): strin
   var field_i = 0
   for syntax in instruction.syntax:
     if syntax == "":
-      source &= "%" & $char(ord('a') + field_i) & "(" & isa_spec.field_types[instruction.fields[field_i].id].name & ")"
+      source &= "%" & $char(ord('a') + field_i) & "("
+      if instruction.raw_fields.len == 0:
+        source &= isa_spec.field_types[instruction.fields[field_i].id].name
+      else:
+        for i, field_type in instruction.raw_fields[field_i]:
+          if i != 0:
+            source &= "|"
+          source &= isa_spec.field_types[field_type.id].name
+      source &= ")"
       field_i += 1
     else:
       source &= syntax

--- a/isa_spec.nim
+++ b/isa_spec.nim
@@ -4,11 +4,17 @@ import types, parse, expressions
 export parse.new_stream_slice
 
 func instruction_to_string*(isa_spec: isa_spec, instruction: instruction): string =
+  func field_define(i: int): string =
+    if instruction.field_sign[i] == sk_unsigned:
+      "%" & $char(ord('a') + i)
+    else:
+      "%" & $char(ord('a') + i) & ":" & "usi"[instruction.field_sign[i].ord]
+
   var source = ""
   var field_i = 0
   for syntax in instruction.syntax:
     if syntax == "":
-      source &= "%" & $char(ord('a') + field_i) & "("
+      source &= field_define(field_i) & "("
       if instruction.raw_fields.len == 0:
         source &= isa_spec.field_types[instruction.fields[field_i].id].name
       else:
@@ -19,8 +25,19 @@ func instruction_to_string*(isa_spec: isa_spec, instruction: instruction): strin
       source &= ")"
       field_i += 1
     else:
-      source &= syntax
+      source &= syntax.replace("%", "%%")
   source &= "\n"
+
+  for expr in instruction.virtual_fields:
+      source &= field_define(field_i) & " = " & $expr & "\n"
+      field_i += 1
+
+  for (lhs, rhs, msg) in instruction.asserts:
+      source &= &"!assert {lhs} == {rhs}"
+      if msg != "":
+        source &= " " & make_escaped_string(msg)
+      source &= "\n"
+      field_i += 1
 
   for i, bit_type in instruction.bits:
     if bit_type.id < FIXED_FIELDS_LEN:
@@ -35,12 +52,35 @@ func instruction_to_string*(isa_spec: isa_spec, instruction: instruction): strin
   return source
 
 func spec_to_string*(isa_spec: isa_spec): string =
-  var source = "[fields]\n"
+  var source = ""
 
-  const FIXED_FIELDS_LEN = 5
+  source &= "[settings]\n"
+
+  if isa_spec.name != "":
+    source &= &"name = {make_escaped_string(isa_spec.name)}\n"
+  if isa_spec.variant != "":
+    source &= &"variant = {make_escaped_string(isa_spec.variant)}\n"
+  if isa_spec.endianness != end_little:
+    source &= &"endianness = {($isa_spec.endianness)[4..^1]}\n"
+  if isa_spec.line_comments != @[";", "//"]:
+    source &= "line_comments = ["
+    for i, lc in isa_spec.line_comments:
+      if i != 0:
+        source &= ", "
+      source &= make_escaped_string(lc)
+    source &= "]\n"
+  if isa_spec.block_comments != @{"/*" : "*/"}:
+    source &= "block_comments = {"
+    for i, (l, r) in isa_spec.block_comments:
+      if i != 0:
+        source &= ", "
+      source &= &"{make_escaped_string(l)}: {make_escaped_string(r)}"
+    source &= "}\n"
+
+  source &= "[fields]\n"
 
   for field_type in isa_spec.field_types[FIXED_FIELDS_LEN..^1]:
-    
+
     source &= "\n" & field_type.name & "\n"
 
     for field_value in field_type.values:
@@ -294,6 +334,11 @@ func parse_isa_spec*(file_name: string, source: string): spec_parse_result =
             message: input))
 
   template `?`[T](input: (string, T)): T =
+    let (err, res) = input
+    if err != "":
+      return error(err)
+    res
+  template `?`(input: (string, stream_slice)): stream_slice =
     let (err, res) = input
     if err != "":
       return error(err)

--- a/parse.nim
+++ b/parse.nim
@@ -402,6 +402,17 @@ func descape_string_content*(s: stream_slice): (string, string) =
       else:
         return (&"Invalid escape character '{nc}'", "")
 
+func make_escaped_string*(s: string, quote = '"'): string =
+  result &= quote
+  for c in s:
+    if c in {quote, '\\'}:
+      result &= "\\" & c
+    if c in {'\x00'..'\x19'}:
+      result &= "\\x" & toHex(c.ord, 2)
+    else:
+      result &= c
+  result &= quote
+
 func parse_string*(s: stream_slice): (string, string) =
   # To be used with results from get_list_value
   var it = s

--- a/types.nim
+++ b/types.nim
@@ -60,6 +60,22 @@ type expression* = ref object
       lhs*: expression
       rhs*: expression
 
+func `==`*(a, b: expression): bool =
+  if a.isNil() or b.isNil():
+    return a.isNil() == b.isNil()
+  if a.exp_kind != b.exp_kind:
+    return false
+  case a.exp_kind:
+    of exp_fail:
+      return a.msg == b.msg
+    of exp_number:
+      return a.value == b.value
+    of exp_operand:
+      return a.index == b.index
+    of exp_operation:
+      return a.op_kind == b.op_kind and a.lhs == b.lhs and a.rhs == b.rhs
+
+
 type sign_kind* = enum
   sk_unsigned # 0 to 255
   sk_signed # -128 to 127


### PR DESCRIPTION
Also adds tests for this.

`expression` previously were only compared by identity, this is now fixed (this means that technically `expr == expr` can result in an infinite loop if they are both self-recursive, but that would result in a stack overflow in all other functions as well)