### PR TITLE
A bit of cleanup, delete spec_to_string

### DIFF
--- a/assemble.nim
+++ b/assemble.nim
@@ -148,23 +148,24 @@ func parse_instruction(s: var StreamSlice, p: ParseContext, inst: Instruction): 
 
   var i = 0
   for syntax in inst.syntax:
-    if syntax.kind == sk_any_number_of_spaces:
-      p.isa_spec.skip_whitespaces(s)
-      continue
-
-    if syntax.kind == sk_at_least_one_space:
-      let start_index = s.get_index()
-      p.isa_spec.skip_whitespaces(s)
-      if s.get_index() == start_index:
-        return error("Expected whitespace here", i)
-      continue
-
-    if syntax.text != "":
-      if not matches(s, syntax.text):
-        if i == 0:
-          return error(&"Unknown instruction", i)
-        return error(&"Expected '{syntax}' after '" & $from_line_start(s) & "'", i)
-      continue
+    case syntax.kind:
+      of sk_any_number_of_spaces:
+        p.isa_spec.skip_whitespaces(s)
+        continue
+      of sk_at_least_one_space:
+        let start_index = s.get_index()
+        p.isa_spec.skip_whitespaces(s)
+        if s.get_index() == start_index:
+          return error("Expected whitespace here", i)
+        continue
+      of sk_fixed:
+        if not matches(s, syntax.text):
+          if i == 0:
+            return error(&"Unknown instruction", i)
+          return error(&"Expected '{syntax}' after '" & $from_line_start(s) & "'", i)
+        continue
+      of sk_field:
+        discard
 
     let restore = s
     for j, field in inst.operands[i].options:

--- a/types.nim
+++ b/types.nim
@@ -133,10 +133,10 @@ type Bitfield* = object
   top*: int
   bottom*: int
   is_direct*: bool
-  is_continue*: bool # This field is broken up by a 64bit boundary
 
 type SyntaxKind* = enum
-  sk_normal
+  sk_fixed
+  sk_field
   sk_any_number_of_spaces
   sk_at_least_one_space
 
@@ -277,8 +277,3 @@ proc lsr*(a: int, b: int): int =
 
 proc asr*(a: uint64, b: uint64): uint64 =
   return cast[uint64](cast[int](a) shr cast[int](b))
-
-
-
-
-echo string


### PR DESCRIPTION
Also adds an error message if an undefined field is used with bitslice syntax, as reported in https://discord.com/channels/828292123936948244/1290690776338272377/1292812367112962160 (other places might still be missing, I did not do a systematic check)