### PR TITLE
Fix x86

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,4 +21,4 @@ jobs:
         hash -r
         popd
 
-        nim r run_tests.nim
+        nim r -d:release run_tests.nim

--- a/run_tests.nim
+++ b/run_tests.nim
@@ -11,7 +11,7 @@ when existsEnv("CI"): # if we are running in Contious Integeration testing (e.g.
   const MANY_SUBTESTS_THRESHOLD   = 0
 else:
   const STOP_AT_FIRST_FAIL        = true
-  const RUN_SINGLE_TEST           = "x86_64" # Emtpy string means run all tests
+  const RUN_SINGLE_TEST           = "" # Emtpy string means run all tests
   const RUN_SUBTESTS: seq[string] = @[] # E.g. @["x86_64", "x86_64.and"], both the spec name and the spec name + subtest id need to be listed.
   const SKIP_TESTS: seq[string]   = @["x86_64"]
   const GENERATE_TOKEN_LIST       = false # If true, all tests that get run and have a [isa_]tokens file get the "golden" set of tokens output

--- a/spec_lib/x86_64/x86_64.isa
+++ b/spec_lib/x86_64/x86_64.isa
@@ -579,7 +579,7 @@ mov  %rm(qreg) , %reg(qreg)
 // mov qreg, [imm]
 // mov  rax , %_(qword_ptr) [ %imm:U64(immediate) ]
 mov  %_(qword_ptr) %reg(qreg) , [ %disp:S64(immediate) ]
-01001 %reg[3:3] 0 %base[3:3] 10001011 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
+01001 %reg[3:3] 0 0 10001011 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 
 // mov qreg, [qreg]
@@ -649,7 +649,7 @@ mov  %_(dword_ptr) %reg(dreg) , [ %disp:S64(immediate) ]
 10001011 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 mov  %_(dword_ptr) %reg(dreg) , [ %disp:S64(immediate) ]
-01000 %reg[3:3] 0 %base[3:3] 10001011 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
+01000 %reg[3:3] 0 0 10001011 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 
 // mov dreg, [qreg]
@@ -760,7 +760,7 @@ mov  %_(word_ptr) %reg(wreg) , [ %disp:S64(immediate) ]
 01100110 10001011 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 mov  %_(word_ptr) %reg(wreg) , [ %disp:S64(immediate) ]
-01100110 01000 %reg[3:3] 0 %base[3:3] 10001011 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
+01100110 01000 %reg[3:3] 0 0 10001011 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 
 // mov wreg, [qreg]
@@ -871,7 +871,7 @@ mov  %_(byte_ptr) %reg(breg_norex) , [ %disp:S64(immediate) ]
 10001010 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 mov  %_(byte_ptr) %reg(breg) , [ %disp:S64(immediate) ]
-01000 %reg[3:3] 0 %base[3:3] 10001010 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
+01000 %reg[3:3] 0 0 10001010 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 
 // mov breg, [qreg]
@@ -1057,7 +1057,7 @@ mov  %_(dword_ptr) [ %disp:S64(immediate) ] , %reg(dreg)
 10001001 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 mov  %_(dword_ptr) [ %disp:S64(immediate) ] , %reg(dreg)
-01000 %reg[3:3] 0 %base[3:3] 10001001 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
+01000 %reg[3:3] 0 0 10001001 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 
 // mov [qreg], dreg
@@ -1168,7 +1168,7 @@ mov  %_(word_ptr) [ %disp:S64(immediate) ] , %reg(wreg)
 01100110 10001001 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 mov  %_(word_ptr) [ %disp:S64(immediate) ] , %reg(wreg)
-01100110 01000 %reg[3:3] 0 %base[3:3] 10001001 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
+01100110 01000 %reg[3:3] 0 0 10001001 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 
 // mov [qreg], wreg
@@ -1278,7 +1278,7 @@ mov  %_(byte_ptr) [ %disp:S64(immediate) ] , %reg(breg_norex)
 10001000 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 mov  %_(byte_ptr) [ %disp:S64(immediate) ] , %reg(breg)
-01000 %reg[3:3] 0 %base[3:3] 10001000 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
+01000 %reg[3:3] 0 0 10001000 00 %reg[2:0] 100 00 100 101 %disp[7:0] %disp[15:8] %disp[23:16] %disp[31:24]
 
 
 // mov [qreg], breg


### PR DESCRIPTION
Also adds the ability to run only specific subtests for a single (useful primarily for x86 ofcourse)

And I decided to add `-d:release` to the github actions execution. Yes, this means that asserts are not executed, but the x10 speedup is IMO worth it, especially since we don't have an infinite amount of github actions time for free. Once the speed of parsing is more acceptable for these tests, we can change this back.